### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ src/main/resources/docs/
 /out/
 /*.iml
 
+# VSCode files
+/.vscode
+/bin
+
 # Storage/log files
 /data/
 /config.json


### PR DESCRIPTION
Some members are using VSCode as part of their workflow.

Running or debugging the programs through VSCode will generate the `/bin` folder if the program is not run through `./gradlew`.

This will prevent commits accidentally including generated `/bin` files.

`/.vscode` folder will also be excluded for each member to have their own configuration.

Might want to consider removing this from `.gitignore` if there is a need to streamline the workflow and ensure everyone is working with the same settings.

Resolves #63 