### PR TITLE
Add unschedule Command

### DIFF
--- a/src/main/java/seedu/findvisor/logic/commands/UnscheduleCommand.java
+++ b/src/main/java/seedu/findvisor/logic/commands/UnscheduleCommand.java
@@ -1,0 +1,102 @@
+package seedu.findvisor.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.findvisor.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.findvisor.commons.core.index.Index;
+import seedu.findvisor.commons.util.ToStringBuilder;
+import seedu.findvisor.logic.Messages;
+import seedu.findvisor.logic.commands.exceptions.CommandException;
+import seedu.findvisor.model.Model;
+import seedu.findvisor.model.person.Address;
+import seedu.findvisor.model.person.Email;
+import seedu.findvisor.model.person.Name;
+import seedu.findvisor.model.person.Person;
+import seedu.findvisor.model.person.Phone;
+import seedu.findvisor.model.tag.Tag;
+
+/**
+ * Unschedules a meeting with a person.
+ */
+public class UnscheduleCommand extends Command {
+    public static final String COMMAND_WORD = "unschedule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unschedules a meeting with the person identified "
+            + "by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_UNSCHEDULE_SUCCESS = "Unscheduled meeting with %1$s";
+    public static final String MESSAGE_NO_MEETING_TO_UNSCHEDULE = "No scheduled meeting with %1$s!";
+
+    private final Index targetIndex;
+
+    /**
+     * Creates an UnscheduleCommand to unschedule a meeting with the person at the specified {@code Index}
+     */
+    public UnscheduleCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
+        if (personToEdit.getMeeting().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_MEETING_TO_UNSCHEDULE);
+        }
+        Person editedPerson = createEditedPerson(personToEdit);
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_UNSCHEDULE_SUCCESS, editedPerson.getName()));
+    }
+
+    /**
+     * Creates and returns a copy of {@code personToEdit} with meeting unscheduled.
+     */
+    private static Person createEditedPerson(Person personToEdit) {
+        assert personToEdit != null;
+
+        Name name = personToEdit.getName();
+        Phone phone = personToEdit.getPhone();
+        Email email = personToEdit.getEmail();
+        Address address = personToEdit.getAddress();
+        Set<Tag> tags = personToEdit.getTags();
+
+        return new Person(name, phone, email, address, tags, Optional.empty());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UnscheduleCommand)) {
+            return false;
+        }
+
+        UnscheduleCommand otherScheduleCommand = (UnscheduleCommand) other;
+        return targetIndex.equals(otherScheduleCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("toUnschedule", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/findvisor/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/findvisor/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.findvisor.logic.commands.FindCommand;
 import seedu.findvisor.logic.commands.HelpCommand;
 import seedu.findvisor.logic.commands.ListCommand;
 import seedu.findvisor.logic.commands.ScheduleCommand;
+import seedu.findvisor.logic.commands.UnscheduleCommand;
 import seedu.findvisor.logic.parser.exceptions.ParseException;
 
 /**
@@ -59,6 +60,9 @@ public class AddressBookParser {
 
         case ScheduleCommand.COMMAND_WORD:
             return new ScheduleCommandParser().parse(arguments);
+
+        case UnscheduleCommand.COMMAND_WORD:
+            return new UnscheduleCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/findvisor/logic/parser/UnscheduleCommandParser.java
+++ b/src/main/java/seedu/findvisor/logic/parser/UnscheduleCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.findvisor.logic.parser;
+
+import static seedu.findvisor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.findvisor.commons.core.index.Index;
+import seedu.findvisor.logic.commands.UnscheduleCommand;
+import seedu.findvisor.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UnscheduleCommand object
+ */
+public class UnscheduleCommandParser implements Parser<UnscheduleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnscheduleCommand
+     * and returns a UnscheduleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnscheduleCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new UnscheduleCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnscheduleCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -26,8 +26,8 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "meeting" : {
-      "start" : "",
-      "end" : ""
+      "start" : "12-03-2024T14:00",
+      "end" : "12-03-2024T15:00"
     },
     "tags" : [ ]
   }, {

--- a/src/test/java/seedu/findvisor/logic/commands/UnscheduleCommandTest.java
+++ b/src/test/java/seedu/findvisor/logic/commands/UnscheduleCommandTest.java
@@ -87,6 +87,13 @@ public class UnscheduleCommandTest {
     }
 
     @Test
+    public void execute_noMeetingToUnschedule_throwsCommandException() {
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(INDEX_FIRST_PERSON);
+
+        assertCommandFailure(unscheduleCommand, model, UnscheduleCommand.MESSAGE_NO_MEETING_TO_UNSCHEDULE);
+    }
+
+    @Test
     public void equals() {
         UnscheduleCommand unscheduleFirstCommand = new UnscheduleCommand(INDEX_FIRST_PERSON);
         UnscheduleCommand unscheduleSecondCommand = new UnscheduleCommand(INDEX_SECOND_PERSON);

--- a/src/test/java/seedu/findvisor/logic/commands/UnscheduleCommandTest.java
+++ b/src/test/java/seedu/findvisor/logic/commands/UnscheduleCommandTest.java
@@ -1,0 +1,119 @@
+package seedu.findvisor.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.findvisor.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.findvisor.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.findvisor.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.findvisor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.findvisor.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.findvisor.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.findvisor.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.findvisor.commons.core.index.Index;
+import seedu.findvisor.logic.Messages;
+import seedu.findvisor.model.Model;
+import seedu.findvisor.model.ModelManager;
+import seedu.findvisor.model.UserPrefs;
+import seedu.findvisor.model.person.Person;
+import seedu.findvisor.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnscheduleCommand}.
+ */
+public class UnscheduleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToUnschedule = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(INDEX_THIRD_PERSON);
+        PersonBuilder personBuilder = new PersonBuilder(personToUnschedule).withMeeting(Optional.empty());
+        Person editedPerson = personBuilder.build();
+
+        String expectedMessage = String.format(UnscheduleCommand.MESSAGE_UNSCHEDULE_SUCCESS,
+                personToUnschedule.getName());
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToUnschedule, editedPerson);
+
+        assertCommandSuccess(unscheduleCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(outOfBoundIndex);
+
+        assertCommandFailure(unscheduleCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_THIRD_PERSON);
+
+        Person personToUnschedule = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(INDEX_FIRST_PERSON);
+        PersonBuilder personBuilder = new PersonBuilder(personToUnschedule).withMeeting(Optional.empty());
+        Person editedPerson = personBuilder.build();
+
+        String expectedMessage = String.format(UnscheduleCommand.MESSAGE_UNSCHEDULE_SUCCESS,
+                personToUnschedule.getName());
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personToUnschedule, editedPerson);
+
+        assertCommandSuccess(unscheduleCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(outOfBoundIndex);
+
+        assertCommandFailure(unscheduleCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        UnscheduleCommand unscheduleFirstCommand = new UnscheduleCommand(INDEX_FIRST_PERSON);
+        UnscheduleCommand unscheduleSecondCommand = new UnscheduleCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(unscheduleFirstCommand.equals(unscheduleFirstCommand));
+
+        // same values -> returns true
+        UnscheduleCommand unscheduleFirstCommandCopy = new UnscheduleCommand(INDEX_FIRST_PERSON);
+        assertTrue(unscheduleFirstCommand.equals(unscheduleFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unscheduleFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unscheduleFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(unscheduleFirstCommand.equals(unscheduleSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        UnscheduleCommand unscheduleCommand = new UnscheduleCommand(targetIndex);
+        String expected = UnscheduleCommand.class.getCanonicalName() + "{toUnschedule=" + targetIndex + "}";
+        assertEquals(expected, unscheduleCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/findvisor/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/findvisor/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.findvisor.logic.commands.FindCommand;
 import seedu.findvisor.logic.commands.HelpCommand;
 import seedu.findvisor.logic.commands.ListCommand;
 import seedu.findvisor.logic.commands.ScheduleCommand;
+import seedu.findvisor.logic.commands.UnscheduleCommand;
 import seedu.findvisor.logic.parser.exceptions.ParseException;
 import seedu.findvisor.model.person.Meeting;
 import seedu.findvisor.model.person.NameContainsKeywordsPredicate;
@@ -102,6 +103,13 @@ public class AddressBookParserTest {
                 + PREFIX_START_DATETIME + dateTimeToInputString(meeting.start) + " "
                 + PREFIX_END_DATETIME + dateTimeToInputString(meeting.end));
         assertEquals(new ScheduleCommand(INDEX_FIRST_PERSON, meeting), command);
+    }
+
+    @Test
+    public void parseCommand_unschedule() throws Exception {
+        UnscheduleCommand command = (UnscheduleCommand) parser.parseCommand(
+                UnscheduleCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new UnscheduleCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/findvisor/logic/parser/UnscheduleCommandParserTest.java
+++ b/src/test/java/seedu/findvisor/logic/parser/UnscheduleCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.findvisor.logic.parser;
+
+import static seedu.findvisor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.findvisor.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.findvisor.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.findvisor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.findvisor.logic.commands.UnscheduleCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the UnscheduleCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the UnscheduleCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class UnscheduleCommandParserTest {
+
+    private UnscheduleCommandParser parser = new UnscheduleCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnscheduleCommand() {
+        assertParseSuccess(parser, "1", new UnscheduleCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnscheduleCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/findvisor/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/findvisor/testutil/TypicalPersons.java
@@ -10,7 +10,6 @@ import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.findvisor.logic.commands.CommandTestUtil.createValidMeeting;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/test/java/seedu/findvisor/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/findvisor/testutil/TypicalPersons.java
@@ -10,12 +10,16 @@ import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.findvisor.logic.commands.CommandTestUtil.createValidMeeting;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import seedu.findvisor.model.AddressBook;
+import seedu.findvisor.model.person.Meeting;
 import seedu.findvisor.model.person.Person;
 
 /**
@@ -32,7 +36,10 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street")
+            .withMeeting(Optional.of(new Meeting(
+                        LocalDateTime.of(2024, 3, 12, 14, 0, 0),
+                        LocalDateTime.of(2024, 3, 12, 15, 0, 0)))).build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")


### PR DESCRIPTION
#2 has to be merged first

- Add new command `schedule` to schedule meetings
- Modify storage to also serialize meetings
- Update existing tests to work with meetings
- Write constraints message for Meeting
- Show correct error message when there is missing argument
- Don't allow scheduling when there is an existing meeting
- Change schedule command prefixes to match spec
- Update datetime input and output formats to match spec
- Only check if meeting start is not after current datetime in the command
- Update command output to match spec
- Additional renames to fix compilation errors
- Added Tests for DateTimeUtil
- Fix datetime format in meeting constraint message
- Add tests for schedule command
- Remove unnecessary assertion and make use of class method
- Only compare up to minutes for meeting equality check
- Add tests for schedule command parser
- Add tests for Meeting
- Update tests for person
- Add tests for JsonAdaptedMeeting and fix its expected behavior
- Update tests for JsonAdaptedPersonTest
- Update tests for AddressBookParserTest
- Fix checkstyle errors
- Add unschedule command
- Update AddressBookParserTest
- Add test for UnscheduleCommandParser
- Add tests for UnscheduleCommandTest
- Remove unused import
