### PR TITLE
bugfix for edit not copyign meeting details over

### DIFF
--- a/src/main/java/seedu/findvisor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/findvisor/logic/commands/EditCommand.java
@@ -100,8 +100,9 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        Optional<Meeting> meeting = personToEdit.getMeeting();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        // EditCommand does not edit meeting so we keep the original meeting
+        Optional<Meeting> meeting = personToEdit.getMeeting();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, meeting);
     }

--- a/src/main/java/seedu/findvisor/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/findvisor/logic/commands/EditCommand.java
@@ -23,6 +23,7 @@ import seedu.findvisor.logic.commands.exceptions.CommandException;
 import seedu.findvisor.model.Model;
 import seedu.findvisor.model.person.Address;
 import seedu.findvisor.model.person.Email;
+import seedu.findvisor.model.person.Meeting;
 import seedu.findvisor.model.person.Name;
 import seedu.findvisor.model.person.Person;
 import seedu.findvisor.model.person.Phone;
@@ -99,9 +100,10 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Optional<Meeting> meeting = personToEdit.getMeeting();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, meeting);
     }
 
     @Override

--- a/src/test/java/seedu/findvisor/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/findvisor/logic/commands/EditCommandTest.java
@@ -152,6 +152,7 @@ public class EditCommandTest {
      */
     @Test
     public void execute_copyMeetingDetails_success() {
+        // The person at the third index of the unfiltered list has a non-empty meeting object
         Person personWithMeeting = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
         PersonBuilder personInList = new PersonBuilder(personWithMeeting);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).build();

--- a/src/test/java/seedu/findvisor/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/findvisor/logic/commands/EditCommandTest.java
@@ -13,6 +13,7 @@ import static seedu.findvisor.logic.commands.CommandTestUtil.assertCommandSucces
 import static seedu.findvisor.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.findvisor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.findvisor.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.findvisor.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.findvisor.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -144,6 +145,26 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Ensure that the meeting details are copied over when a person is edited.
+     */
+    @Test
+    public void execute_copyMeetingDetails_success() {
+        Person personWithMeeting = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
+        PersonBuilder personInList = new PersonBuilder(personWithMeeting);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).build();
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_THIRD_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personWithMeeting, editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test


### PR DESCRIPTION
- Copy over the meeting object to the newly edited person
- Add commment to explain why we are copying from personToEdit directly
- Add test for this bug so we don't regress
