### PR TITLE
Enable assertions in `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'findvisor.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
As stated in the Week 10's project brief [here](https://nus-cs2103-ay2324s2.github.io/website/schedule/week10/project.html#3-start-the-next-iteration), we are required to enable assertions for v1.3.

Closes #115 