### PR TITLE
Bump version for v1.3 trial release

### DIFF
--- a/src/main/java/seedu/findvisor/MainApp.java
+++ b/src/main/java/seedu/findvisor/MainApp.java
@@ -36,7 +36,7 @@ import seedu.findvisor.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 2, true);
+    public static final Version VERSION = new Version(1, 3, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 


### PR DESCRIPTION
The version of FINDvisor shown during startup will now be
```
INFO: Starting FINDvisor V1.3.0ea
```
`ea` stands for early access, when we do the official release, it will be removed.
