### PR TITLE
Add address searching feature to find command

### DIFF
--- a/src/main/java/seedu/findvisor/logic/Messages.java
+++ b/src/main/java/seedu/findvisor/logic/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_EMPTY_FIELD = "Empty value for field: %1$s!";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/findvisor/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/findvisor/logic/commands/FindCommand.java
@@ -1,6 +1,7 @@
 package seedu.findvisor.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -15,7 +16,7 @@ import seedu.findvisor.model.person.Person;
 
 /**
  * Finds persons based on search criteria of the specified category.
- * Only exactly one category of the following can be specified, either name, email, phone or tags.
+ * Only exactly one category of the following can be specified, either name, email, phone, address or tags.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
@@ -29,6 +30,7 @@ public class FindCommand extends Command {
             + PREFIX_NAME + "NAME | "
             + PREFIX_EMAIL + "EMAIL | "
             + PREFIX_PHONE + "PHONE | "
+            + PREFIX_ADDRESS + "ADDRESS | "
             + PREFIX_TAG + "TAG...\n"
             + "Example: " + COMMAND_WORD + " t/PRUActiveCash t/friends";
 

--- a/src/main/java/seedu/findvisor/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/findvisor/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,17 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Verifies that no value associated with the given {@code prefix} in the {@code argMultimap} is blank.
+     * A {@code prefix} value is blank if it is empty or has only whitespace.
+     * @throws ParseException if any of the values associated with the {@code prefix}
+     */
+    public void verifyNoBlankPrefixValueFor(Prefix prefix) throws ParseException {
+        List<String> prefixValues = argMultimap.get(prefix);
+        boolean hasBlankPrefixValue = prefixValues.stream().anyMatch(String::isBlank);
+        if (hasBlankPrefixValue) {
+            throw new ParseException(String.format(Messages.MESSAGE_EMPTY_FIELD, prefix.getPrefix()));
+        }
+    }
 }

--- a/src/main/java/seedu/findvisor/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/findvisor/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.findvisor.logic.parser;
 
 import static seedu.findvisor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 
 import seedu.findvisor.logic.commands.FindCommand;
 import seedu.findvisor.logic.parser.exceptions.ParseException;
+import seedu.findvisor.model.person.AddressContainsKeywordPredicate;
 import seedu.findvisor.model.person.EmailContainsKeywordPredicate;
 import seedu.findvisor.model.person.NameContainsKeywordPredicate;
 import seedu.findvisor.model.person.PhoneContainsKeywordPredicate;
@@ -28,27 +30,36 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
-        if (!isSinglePrefixPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TAG)) {
+        if (!isSinglePrefixPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            argMultimap.verifyNoBlankPrefixValueFor(PREFIX_NAME);
             String nameKeyword = argMultimap.getValue(PREFIX_NAME).get();
             return new FindCommand(new NameContainsKeywordPredicate(nameKeyword));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            argMultimap.verifyNoBlankPrefixValueFor(PREFIX_EMAIL);
             String emailKeyword = argMultimap.getValue(PREFIX_EMAIL).get();
             return new FindCommand(new EmailContainsKeywordPredicate(emailKeyword));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            argMultimap.verifyNoBlankPrefixValueFor(PREFIX_PHONE);
             String phoneKeyword = argMultimap.getValue(PREFIX_PHONE).get();
             return new FindCommand(new PhoneContainsKeywordPredicate(phoneKeyword));
         }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            argMultimap.verifyNoBlankPrefixValueFor(PREFIX_ADDRESS);
+            String addressKeyword = argMultimap.getValue(PREFIX_ADDRESS).get();
+            return new FindCommand(new AddressContainsKeywordPredicate(addressKeyword));
+        }
 
+        argMultimap.verifyNoBlankPrefixValueFor(PREFIX_TAG);
         List<String> tagsKeywords = argMultimap.getAllValues(PREFIX_TAG);
         return new FindCommand(new TagsContainsKeywordsPredicate(tagsKeywords));
     }

--- a/src/main/java/seedu/findvisor/model/person/AddressContainsKeywordPredicate.java
+++ b/src/main/java/seedu/findvisor/model/person/AddressContainsKeywordPredicate.java
@@ -1,0 +1,48 @@
+package seedu.findvisor.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.findvisor.commons.util.StringUtil;
+import seedu.findvisor.commons.util.ToStringBuilder;
+
+/**
+ * A predicate for evaluating if a {@link Person}'s address contains (case-insensitive) a given keyword.
+ * This is used to filter for persons based on their address attribute.
+ */
+public class AddressContainsKeywordPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    /**
+     * Constructs an {@code AddressContainsKeywordPredicate} with the specified keyword.
+     *
+     * @param keyword The keyword to be matched against the person's address. The match is case-insensitive.
+     */
+    public AddressContainsKeywordPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return StringUtil.containsIgnoreCase(person.getAddress().value, keyword);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddressContainsKeywordPredicate)) {
+            return false;
+        }
+
+        AddressContainsKeywordPredicate otherAddressContainsKeywordsPredicate = (AddressContainsKeywordPredicate) other;
+        return keyword.equals(otherAddressContainsKeywordsPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("address", keyword).toString();
+    }
+}

--- a/src/test/java/seedu/findvisor/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/findvisor/logic/commands/CommandTestUtil.java
@@ -56,6 +56,13 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String REMARK_DESC = " " + PREFIX_REMARK + REMARK;
 
+    public static final String EMPTY_NAME_DESC = " " + PREFIX_NAME;
+    public static final String EMPTY_PHONE_DESC = " " + PREFIX_PHONE;
+    public static final String EMPTY_EMAIL_DESC = " " + PREFIX_EMAIL;
+    public static final String EMPTY_ADDRESS_DESC = " " + PREFIX_ADDRESS;
+    public static final String EMPTY_TAG_DESC = " " + PREFIX_TAG;
+    public static final String INCOMPLETE_TAG_DESC = " " + PREFIX_TAG + " " + PREFIX_TAG + "friends";
+
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol

--- a/src/test/java/seedu/findvisor/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/findvisor/logic/commands/FindCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.findvisor.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import seedu.findvisor.model.Model;
 import seedu.findvisor.model.ModelManager;
 import seedu.findvisor.model.UserPrefs;
+import seedu.findvisor.model.person.AddressContainsKeywordPredicate;
 import seedu.findvisor.model.person.EmailContainsKeywordPredicate;
 import seedu.findvisor.model.person.NameContainsKeywordPredicate;
 import seedu.findvisor.model.person.Person;
@@ -122,6 +124,16 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_nonExistentAddress_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate(VALID_ADDRESS_AMY);
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
     public void execute_nonExistentTag_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         TagsContainsKeywordsPredicate tagsPredicate = new TagsContainsKeywordsPredicate(
@@ -161,6 +173,16 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_existingAddress_personFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate(BENSON.getAddress().value);
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/findvisor/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/findvisor/logic/parser/FindCommandParserTest.java
@@ -1,8 +1,13 @@
 package seedu.findvisor.logic.parser;
 
 import static seedu.findvisor.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.findvisor.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.findvisor.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.findvisor.logic.commands.CommandTestUtil.EMPTY_NAME_DESC;
+import static seedu.findvisor.logic.commands.CommandTestUtil.EMPTY_PHONE_DESC;
+import static seedu.findvisor.logic.commands.CommandTestUtil.EMPTY_TAG_DESC;
+import static seedu.findvisor.logic.commands.CommandTestUtil.INCOMPLETE_TAG_DESC;
 import static seedu.findvisor.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.findvisor.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.findvisor.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -14,6 +19,7 @@ import static seedu.findvisor.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.findvisor.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.findvisor.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -23,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.findvisor.logic.Messages;
 import seedu.findvisor.logic.commands.FindCommand;
+import seedu.findvisor.model.person.AddressContainsKeywordPredicate;
 import seedu.findvisor.model.person.EmailContainsKeywordPredicate;
 import seedu.findvisor.model.person.NameContainsKeywordPredicate;
 import seedu.findvisor.model.person.PhoneContainsKeywordPredicate;
@@ -57,6 +64,10 @@ public class FindCommandParserTest {
         expectedFindCommand = new FindCommand(new PhoneContainsKeywordPredicate("81234567"));
         assertParseSuccess(parser, PHONE_DESC_BOB, expectedFindCommand);
 
+        // parse address
+        expectedFindCommand = new FindCommand(new AddressContainsKeywordPredicate("Block 123, Bobby Street 3"));
+        assertParseSuccess(parser, ADDRESS_DESC_BOB, expectedFindCommand);
+
         // parse multiple tags
         expectedFindCommand = new FindCommand(new TagsContainsKeywordsPredicate(
                 Arrays.asList(new String[]{"friend", "husband"})));
@@ -87,5 +98,21 @@ public class FindCommandParserTest {
 
         // Multiple valid prefixes
         assertParseFailure(parser, VALID_NAME_AMY + " " + VALID_EMAIL_AMY, expectedMessage);
+    }
+
+    @Test
+    public void parse_emptyArgs_failure() {
+        // Empty name prefix
+        assertParseFailure(parser, EMPTY_NAME_DESC, String.format(Messages.MESSAGE_EMPTY_FIELD, PREFIX_NAME));
+
+        // Empty phone prefix
+        assertParseFailure(parser, EMPTY_PHONE_DESC, String.format(Messages.MESSAGE_EMPTY_FIELD, PREFIX_PHONE));
+
+        // Empty tag prefix
+        assertParseFailure(parser, EMPTY_TAG_DESC, String.format(Messages.MESSAGE_EMPTY_FIELD, PREFIX_TAG));
+
+        // One empty tag prefix
+        // Empty tag prefix
+        assertParseFailure(parser, INCOMPLETE_TAG_DESC, String.format(Messages.MESSAGE_EMPTY_FIELD, PREFIX_TAG));
     }
 }

--- a/src/test/java/seedu/findvisor/model/person/AddressContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/findvisor/model/person/AddressContainsKeywordPredicateTest.java
@@ -1,0 +1,88 @@
+package seedu.findvisor.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.findvisor.testutil.PersonBuilder;
+
+public class AddressContainsKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "Block 312, Amy Street 1";
+        String secondPredicateKeyword = "Block 123, Bobby Ave 3";
+
+        AddressContainsKeywordPredicate firstPredicate = new AddressContainsKeywordPredicate(firstPredicateKeyword);
+        AddressContainsKeywordPredicate secondPredicate = new AddressContainsKeywordPredicate(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AddressContainsKeywordPredicate firstPredicateCopy = new AddressContainsKeywordPredicate(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_addressEmpty_exceptionThrown() {
+        // empty address -> exception thrown
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate(" ");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            predicate.test(new PersonBuilder().withAddress("Alice").build());
+        });
+        assertEquals("subString parameter cannot be empty", exception.getMessage());
+    }
+
+    @Test
+    public void test_addressContainsKeyword_returnsTrue() {
+        // different case
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate("30 charlie street");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("30 Charlie Street").build()));
+
+        // Exact word
+        predicate = new AddressContainsKeywordPredicate("12 Bun Ave");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("12 Bun Ave").build()));
+
+        // address contains keyword
+        predicate = new AddressContainsKeywordPredicate("Apple");
+        assertTrue(predicate.test(new PersonBuilder().withAddress("30 Apple Street").build()));
+    }
+
+    @Test
+    public void test_addressDoesNotContainKeyword_returnsFalse() {
+        // Non-matching keyword
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate("Apple");
+        assertFalse(predicate.test(new PersonBuilder().withAddress("30 Charlie Street").build()));
+
+        // Reversed keyword
+        predicate = new AddressContainsKeywordPredicate("Street Charlie 30");
+        assertFalse(predicate.test(new PersonBuilder().withAddress("30 Charlie Street").build()));
+
+        // Keywords match phone, but does not match address
+        predicate = new AddressContainsKeywordPredicate("SixthStreet");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91002921")
+                .withEmail("alice@email.com").withAddress("MainStreet").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String keyword = "30 Apple Ave";
+        AddressContainsKeywordPredicate predicate = new AddressContainsKeywordPredicate(keyword);
+
+        String expected = AddressContainsKeywordPredicate.class.getCanonicalName() + "{address=" + keyword + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Allow search for Persons' addresses that contain user specified string.

Fix a bug where empty parameters for `find` command would not display any message to the UI. This commit will address it by checking if the prefix value is blank, and will throw a ParseException if so.

Closes #82 