### PR TITLE
Safe string validation for meeting remark

### DIFF
--- a/src/main/java/seedu/findvisor/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/findvisor/commons/util/DateTimeUtil.java
@@ -35,6 +35,20 @@ public class DateTimeUtil {
     }
 
     /**
+     * Returns true if {@code dateTime} can be converted into a {@code LocalDateTime}
+     * via {@link LocalDateTime#parse(CharSequence)}, otherwise returns false.
+     * @param dateTime A string representing the date and time.
+     */
+    public static boolean isValidDateTime(String dateTime) {
+        try {
+            LocalDateTime.parse(dateTime, DATE_TIME_INPUT_FORMAT);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Converts a String into a LocalDateTime object. The expected format is dd-MM-yyyy'T'HH:mm. For
      * example, 2023-01-29T14:00.
      *

--- a/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
@@ -169,7 +169,7 @@ public class ParserUtil {
      *
      * @param dateTime The meeting date and time string to parse.
      * @return Parsed {@code LocalDateTime} object.
-     * @throws ParseException
+     * @throws ParseException if the dateTime is invalid.
      */
     public static LocalDateTime parseMeetingDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);

--- a/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
@@ -1,8 +1,10 @@
 package seedu.findvisor.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.findvisor.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
@@ -160,5 +162,38 @@ public class ParserUtil {
             throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
         }
         return Optional.of(new Remark(trimmedRemark));
+    }
+
+    /**
+     * Parses the given meeting remark into a {@code String} object.
+     * Leading and trailing whitespaces for meeting remark will be trimmed.
+     *
+     * @throws ParseException if the meeting remark is invalid.
+     */
+    public static String parseMeetingRemark(String remark) throws ParseException {
+        requireNonNull(remark);
+        String trimmedRemark = remark.trim();
+        if (!Meeting.isValidRemark(trimmedRemark)) {
+            throw new ParseException(Meeting.MESSAGE_REMARK_CONSTRAINTS);
+        }
+        return trimmedRemark;
+    }
+
+    /**
+     * Parses the given start, end datetimes and remark into a {@code Meeting} object.
+     * Leading and trailing whitespaces for meeting remark will be trimmed.
+     *
+     * @throws ParseException if the dateTime or remark is invalid.
+     */
+    public static Meeting parseMeeting(LocalDateTime startDateTime, LocalDateTime endDateTime, String remark)
+            throws ParseException {
+        requireAllNonNull(startDateTime, endDateTime, remark);
+        String parsedRemark = parseMeetingRemark(remark);
+
+        if (!Meeting.isValidDateTime(startDateTime, endDateTime)) {
+            throw new ParseException(Meeting.MESSAGE_DATETIME_CONSTRAINTS);
+        }
+
+        return new Meeting(startDateTime, endDateTime, parsedRemark);
     }
 }

--- a/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/findvisor/logic/parser/ParserUtil.java
@@ -165,9 +165,27 @@ public class ParserUtil {
     }
 
     /**
+     * Parses the given meeting date and time into a {@code LocalDateTime} object.
+     *
+     * @param dateTime The meeting date and time string to parse.
+     * @return Parsed {@code LocalDateTime} object.
+     * @throws ParseException
+     */
+    public static LocalDateTime parseMeetingDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+        if (!DateTimeUtil.isValidDateTime(trimmedDateTime)) {
+            throw new ParseException(Meeting.MESSAGE_DATETIME_CONSTRAINTS);
+        }
+        return DateTimeUtil.parseDateTimeString(trimmedDateTime);
+    }
+
+    /**
      * Parses the given meeting remark into a {@code String} object.
      * Leading and trailing whitespaces for meeting remark will be trimmed.
      *
+     * @param remark The meeting remark to parse.
+     * @return The parsed meeting remark.
      * @throws ParseException if the meeting remark is invalid.
      */
     public static String parseMeetingRemark(String remark) throws ParseException {
@@ -183,6 +201,7 @@ public class ParserUtil {
      * Parses the given start, end datetimes and remark into a {@code Meeting} object.
      * Leading and trailing whitespaces for meeting remark will be trimmed.
      *
+     * @return The parsed {@code Meeting} object.
      * @throws ParseException if the dateTime or remark is invalid.
      */
     public static Meeting parseMeeting(LocalDateTime startDateTime, LocalDateTime endDateTime, String remark)

--- a/src/main/java/seedu/findvisor/logic/parser/RescheduleCommandParser.java
+++ b/src/main/java/seedu/findvisor/logic/parser/RescheduleCommandParser.java
@@ -7,6 +7,8 @@ import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_END_DATETIME;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_MEETING_REMARK;
 import static seedu.findvisor.logic.parser.CliSyntax.PREFIX_START_DATETIME;
 
+import java.time.LocalDateTime;
+
 import seedu.findvisor.commons.core.index.Index;
 import seedu.findvisor.logic.Messages;
 import seedu.findvisor.logic.commands.RescheduleCommand;
@@ -42,13 +44,16 @@ public class RescheduleCommandParser implements Parser<RescheduleCommand> {
         EditMeetingDescriptor editMeetingDescriptor = new EditMeetingDescriptor();
 
         if (argMultimap.getValue(PREFIX_START_DATETIME).isPresent()) {
-            editMeetingDescriptor.setStart(parseDateTimeString(argMultimap.getValue(PREFIX_START_DATETIME).get()));
+            LocalDateTime start = parseDateTimeString(argMultimap.getValue(PREFIX_START_DATETIME).get());
+            editMeetingDescriptor.setStart(start);
         }
         if (argMultimap.getValue(PREFIX_END_DATETIME).isPresent()) {
-            editMeetingDescriptor.setEnd(parseDateTimeString(argMultimap.getValue(PREFIX_END_DATETIME).get()));
+            LocalDateTime end = parseDateTimeString(argMultimap.getValue(PREFIX_END_DATETIME).get());
+            editMeetingDescriptor.setEnd(end);
         }
         if (argMultimap.getValue(PREFIX_MEETING_REMARK).isPresent()) {
-            editMeetingDescriptor.setRemark(argMultimap.getValue(PREFIX_MEETING_REMARK).get());
+            String remark = ParserUtil.parseMeetingRemark(argMultimap.getValue(PREFIX_MEETING_REMARK).get());
+            editMeetingDescriptor.setRemark(remark);
         }
 
         if (!editMeetingDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/findvisor/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/seedu/findvisor/logic/parser/ScheduleCommandParser.java
@@ -57,7 +57,7 @@ public class ScheduleCommandParser implements Parser<ScheduleCommand> {
 
         String remark = argMultimap.getValue(PREFIX_MEETING_REMARK).orElse("");
 
-        Meeting meeting = new Meeting(startDateTime, endDateTime, remark);
+        Meeting meeting = ParserUtil.parseMeeting(startDateTime, endDateTime, remark);
 
         return new ScheduleCommand(index, meeting);
     }

--- a/src/main/java/seedu/findvisor/model/person/Meeting.java
+++ b/src/main/java/seedu/findvisor/model/person/Meeting.java
@@ -3,6 +3,8 @@ package seedu.findvisor.model.person;
 //@@author Dethada
 import static seedu.findvisor.commons.util.AppUtil.checkArgument;
 import static seedu.findvisor.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.findvisor.commons.util.StringUtil.isSafeString;
+import static seedu.findvisor.logic.Messages.MESSAGE_SAFE_STRING_INPUT_CHARACTERS;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -23,7 +25,7 @@ public class Meeting {
     public static final String MESSAGE_DATE_CONSTRAINT = "Meeting date is specified in the following format: "
             + DateTimeUtil.DATE_PATTERN;
     public static final String MESSAGE_REMARK_CONSTRAINTS = "Remark is at most "
-            + MAX_REMARK_LENGTH + " characters long.";
+            + MAX_REMARK_LENGTH + " characters long and can only contain " + MESSAGE_SAFE_STRING_INPUT_CHARACTERS;
 
     public final LocalDateTime start;
     public final LocalDateTime end;
@@ -52,8 +54,13 @@ public class Meeting {
         return start.isBefore(end);
     }
 
+    /**
+     * Returns true if the given remark is valid.
+     * The remark is valid if it is at most {@code MAX_REMARK_LENGTH} characters long and contains only safe characters.
+     */
     public static boolean isValidRemark(String remark) {
-        return remark.length() <= MAX_REMARK_LENGTH;
+        boolean validLength = remark.length() <= MAX_REMARK_LENGTH;
+        return validLength && isSafeString(remark);
     }
 
     public LocalDateTime getStart() {

--- a/src/test/java/seedu/findvisor/commons/util/DateTimeUtilTest.java
+++ b/src/test/java/seedu/findvisor/commons/util/DateTimeUtilTest.java
@@ -33,6 +33,21 @@ public class DateTimeUtilTest {
     }
 
     @Test
+    public void isValidDateTime_invalidString_returnsFalse() {
+        // Invalid string
+        assertFalse(DateTimeUtil.isValidDateTime("Invalid String"));
+
+        // Invalid date format
+        assertFalse(DateTimeUtil.isValidDateTime("2024/10/12"));
+    }
+
+    @Test
+    public void isValidDateTime_validString_returnsTrue() {
+        assertTrue(DateTimeUtil.isValidDateTime("10-12-2024T14:00"));
+        assertTrue(DateTimeUtil.isValidDateTime("01-01-2024T14:00"));
+    }
+
+    @Test
     public void parseDateString_validString() {
         assertEquals(LocalDate.of(2024, 12, 31), DateTimeUtil.parseDateString("31-12-2024"));
     }

--- a/src/test/java/seedu/findvisor/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/findvisor/logic/parser/ParserUtilTest.java
@@ -295,7 +295,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseMeetingDateTime_validValue_returnsLocalDateTime() throws Exception {
-        assertEquals(DateTimeUtil.parseDateTimeString(VALID_DATETIME_STRING), ParserUtil.parseMeetingDateTime(VALID_DATETIME_STRING));
+        assertEquals(DateTimeUtil.parseDateTimeString(VALID_DATETIME_STRING),
+                ParserUtil.parseMeetingDateTime(VALID_DATETIME_STRING));
     }
 
     @Test

--- a/src/test/java/seedu/findvisor/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/findvisor/logic/parser/ParserUtilTest.java
@@ -7,6 +7,7 @@ import static seedu.findvisor.testutil.Assert.assertThrows;
 import static seedu.findvisor.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -19,6 +20,7 @@ import seedu.findvisor.commons.util.DateTimeUtil;
 import seedu.findvisor.logic.parser.exceptions.ParseException;
 import seedu.findvisor.model.person.Address;
 import seedu.findvisor.model.person.Email;
+import seedu.findvisor.model.person.Meeting;
 import seedu.findvisor.model.person.Name;
 import seedu.findvisor.model.person.Phone;
 import seedu.findvisor.model.person.Remark;
@@ -31,6 +33,7 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_DATE_STRING = "10/12/2012";
+    private static final String INVALID_DATETIME_STRING = "INVALID DATETIME STRING";
     private static final String INVALID_REMARK = "/r is ♀";
 
     private static final String VALID_NAME = "Rachel Walker";
@@ -44,7 +47,10 @@ public class ParserUtilTest {
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_DATE_STRING = "10-12-2024";
+    private static final String VALID_DATETIME_STRING = "10-12-2024T14:00";
     private static final String VALID_REMARK = "Wants to own 2 luxury cars worth $3 million each";
+    private static final LocalDateTime START_DATETIME = LocalDateTime.of(2024, 12, 1, 13, 0);
+    private static final LocalDateTime END_DATETIME = LocalDateTime.of(2024, 12, 1, 14, 0);
 
 
     private static final String WHITESPACE = " \t\r\n";
@@ -275,5 +281,58 @@ public class ParserUtilTest {
     @Test
     public void parseRemark_emptyValue_returnsOptionalEmpty() throws Exception {
         assertEquals(Optional.empty(), ParserUtil.parseRemark(""));
+    }
+
+    @Test
+    public void parseMeetingDateTime_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMeetingDateTime(null));
+    }
+
+    @Test
+    public void parseMeetingDateTime_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMeetingDateTime(INVALID_DATETIME_STRING));
+    }
+
+    @Test
+    public void parseMeetingDateTime_validValue_returnsLocalDateTime() throws Exception {
+        assertEquals(DateTimeUtil.parseDateTimeString(VALID_DATETIME_STRING), ParserUtil.parseMeetingDateTime(VALID_DATETIME_STRING));
+    }
+
+    @Test
+    public void parseMeetingRemark_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMeetingRemark(null));
+    }
+
+    @Test
+    public void parseMeetingRemark_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMeetingRemark(INVALID_REMARK));
+    }
+
+    @Test
+    public void parseMeetingRemark_validValue_returnsTrimmedRemark() throws Exception {
+        assertEquals(VALID_REMARK, ParserUtil.parseMeetingRemark(VALID_REMARK));
+    }
+
+    @Test
+    public void parseMeeting_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMeeting(null, null, null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMeeting(START_DATETIME, null, null));
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMeeting(START_DATETIME, END_DATETIME, null));
+    }
+
+    @Test
+    public void parseMeeting_invalidRemark_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMeeting(START_DATETIME, END_DATETIME, INVALID_REMARK));
+    }
+
+    @Test
+    public void parseMeeting_invalidDateTimes_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMeeting(END_DATETIME, START_DATETIME, VALID_REMARK));
+    }
+
+    @Test
+    public void parseMeeting_validMeeting_returnsMeeting() throws Exception {
+        assertEquals(new Meeting(START_DATETIME, END_DATETIME, VALID_REMARK),
+                ParserUtil.parseMeeting(START_DATETIME, END_DATETIME, VALID_REMARK));
     }
 }

--- a/src/test/java/seedu/findvisor/model/person/MeetingTest.java
+++ b/src/test/java/seedu/findvisor/model/person/MeetingTest.java
@@ -52,11 +52,18 @@ public class MeetingTest {
         // null meeting remark
         assertThrows(NullPointerException.class, () -> Meeting.isValidRemark(null));
 
-        // invalid meeting remark
+        // meeting remark too long
         assertFalse(Meeting.isValidRemark(INVALID_MEETING_REMARK));
 
+        // contains invalid character
+        assertFalse(Meeting.isValidRemark("A/B"));
+        assertFalse(Meeting.isValidRemark("Emoji ❤️"));
+        assertFalse(Meeting.isValidRemark("不能使用华文字体"));
+
         // valid meeting remark
+        assertTrue(Meeting.isValidRemark(""));
         assertTrue(Meeting.isValidRemark(VALID_MEETING_REMARK));
+        assertTrue(Meeting.isValidRemark("Owes $100"));
     }
 
     @Test


### PR DESCRIPTION
- Add safe string validation to meeting remark
- Fixed bug where `IllegalArgumentException` was thrown instead of `ParserException`
