### PR TITLE
Fix meeting panel size

### DIFF
--- a/src/main/java/seedu/findvisor/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/findvisor/commons/core/GuiSettings.java
@@ -14,27 +14,31 @@ public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;
     private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_DIVIDER_POSITION = 0.25;
 
     private final double windowWidth;
     private final double windowHeight;
     private final Point windowCoordinates;
+    private final double dividerPosition;
 
     /**
-     * Constructs a {@code GuiSettings} with the default height, width and position.
+     * Constructs a {@code GuiSettings} with the default height, width window position and divider position.
      */
     public GuiSettings() {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
+        dividerPosition = DEFAULT_DIVIDER_POSITION;
     }
 
     /**
-     * Constructs a {@code GuiSettings} with the specified height, width and position.
+     * Constructs a {@code GuiSettings} with the specified height, width window position and divider position.
      */
-    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
+    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, double dividerPosition) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
+        this.dividerPosition = dividerPosition;
     }
 
     public double getWindowWidth() {
@@ -47,6 +51,10 @@ public class GuiSettings implements Serializable {
 
     public Point getWindowCoordinates() {
         return windowCoordinates != null ? new Point(windowCoordinates) : null;
+    }
+
+    public double getDividerPosition() {
+        return dividerPosition;
     }
 
     @Override
@@ -63,12 +71,13 @@ public class GuiSettings implements Serializable {
         GuiSettings otherGuiSettings = (GuiSettings) other;
         return windowWidth == otherGuiSettings.windowWidth
                 && windowHeight == otherGuiSettings.windowHeight
-                && Objects.equals(windowCoordinates, otherGuiSettings.windowCoordinates);
+                && Objects.equals(windowCoordinates, otherGuiSettings.windowCoordinates)
+                && dividerPosition == otherGuiSettings.dividerPosition;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(windowWidth, windowHeight, windowCoordinates);
+        return Objects.hash(windowWidth, windowHeight, windowCoordinates, dividerPosition);
     }
 
     @Override
@@ -77,6 +86,7 @@ public class GuiSettings implements Serializable {
                 .add("windowWidth", windowWidth)
                 .add("windowHeight", windowHeight)
                 .add("windowCoordinates", windowCoordinates)
+                .add("dividerPosition", dividerPosition)
                 .toString();
     }
 }

--- a/src/main/java/seedu/findvisor/ui/MainWindow.java
+++ b/src/main/java/seedu/findvisor/ui/MainWindow.java
@@ -2,13 +2,16 @@ package seedu.findvisor.ui;
 
 import java.util.logging.Logger;
 
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.findvisor.commons.core.GuiSettings;
 import seedu.findvisor.commons.core.LogsCenter;
@@ -35,6 +38,15 @@ public class MainWindow extends UiPart<Stage> {
     private MeetingListPanel meetingListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+
+    @FXML
+    private SplitPane splitPane;
+
+    @FXML
+    private VBox meetingList;
+
+    @FXML
+    private VBox mainAppView;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -65,7 +77,9 @@ public class MainWindow extends UiPart<Stage> {
         this.logic = logic;
 
         // Configure the UI
-        setWindowDefaultSize(logic.getGuiSettings());
+        setDefaultGuiSettings(logic.getGuiSettings());
+        SplitPane.setResizableWithParent(meetingList, false);
+        SplitPane.setResizableWithParent(mainAppView, false);
 
         setAccelerators();
 
@@ -133,13 +147,14 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Sets the default size based on {@code guiSettings}.
      */
-    private void setWindowDefaultSize(GuiSettings guiSettings) {
+    private void setDefaultGuiSettings(GuiSettings guiSettings) {
         primaryStage.setHeight(guiSettings.getWindowHeight());
         primaryStage.setWidth(guiSettings.getWindowWidth());
         if (guiSettings.getWindowCoordinates() != null) {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());
         }
+        Platform.runLater(() -> splitPane.setDividerPosition(0, guiSettings.getDividerPosition()));
     }
 
     /**
@@ -164,7 +179,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
+                (int) primaryStage.getX(), (int) primaryStage.getY(), splitPane.getDividerPositions()[0]);
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -33,7 +33,7 @@
           </Menu>
         </MenuBar>
 
-        <SplitPane orientation="HORIZONTAL" dividerPositions="0.3" VBox.vgrow="ALWAYS">
+        <SplitPane fx:id="splitPane" orientation="HORIZONTAL" dividerPositions="0.25" VBox.vgrow="ALWAYS">
           <VBox fx:id="meetingList" styleClass="pane-with-border" minWidth="200" prefWidth="200" VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
@@ -41,7 +41,7 @@
             <StackPane fx:id="meetingListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <VBox>
+          <VBox fx:id="mainAppView">
             <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
               <padding>
                 <Insets top="5" right="10" bottom="5" left="10" />

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -7,7 +7,8 @@
       "x" : 300,
       "y" : 100,
       "z" : 99
-    }
+    },
+    "dividerPosition" : 0.25
   },
   "addressBookFilePath" : "addressbook.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -5,7 +5,8 @@
     "windowCoordinates" : {
       "x" : 300,
       "y" : 100
-    }
+    },
+    "dividerPosition" : 0.25
   },
   "addressBookFilePath" : "addressbook.json"
 }

--- a/src/test/java/seedu/findvisor/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/findvisor/commons/core/GuiSettingsTest.java
@@ -10,7 +10,7 @@ public class GuiSettingsTest {
         GuiSettings guiSettings = new GuiSettings();
         String expected = GuiSettings.class.getCanonicalName() + "{windowWidth=" + guiSettings.getWindowWidth()
                 + ", windowHeight=" + guiSettings.getWindowHeight() + ", windowCoordinates="
-                + guiSettings.getWindowCoordinates() + "}";
+                + guiSettings.getWindowCoordinates() + ", dividerPosition=" + guiSettings.getDividerPosition() + "}";
         assertEquals(expected, guiSettings.toString());
     }
 }

--- a/src/test/java/seedu/findvisor/model/ModelManagerTest.java
+++ b/src/test/java/seedu/findvisor/model/ModelManagerTest.java
@@ -37,7 +37,7 @@ public class ModelManagerTest {
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
+        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4, 5));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
@@ -54,7 +54,7 @@ public class ModelManagerTest {
 
     @Test
     public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
+        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4, 5);
         modelManager.setGuiSettings(guiSettings);
         assertEquals(guiSettings, modelManager.getGuiSettings());
     }

--- a/src/test/java/seedu/findvisor/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/findvisor/storage/JsonUserPrefsStorageTest.java
@@ -72,7 +72,7 @@ public class JsonUserPrefsStorageTest {
 
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
+        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100, 0.25));
         userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
         return userPrefs;
     }
@@ -103,7 +103,7 @@ public class JsonUserPrefsStorageTest {
     public void saveUserPrefs_allInOrder_success() throws DataLoadingException, IOException {
 
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2));
+        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2, 0.25));
 
         Path pefsFilePath = testFolder.resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);
@@ -114,7 +114,7 @@ public class JsonUserPrefsStorageTest {
         assertEquals(original, readBack);
 
         //Try saving when the file exists
-        original.setGuiSettings(new GuiSettings(5, 5, 5, 5));
+        original.setGuiSettings(new GuiSettings(5, 5, 5, 5, 0.5));
         jsonUserPrefsStorage.saveUserPrefs(original);
         readBack = jsonUserPrefsStorage.readUserPrefs().get();
         assertEquals(original, readBack);

--- a/src/test/java/seedu/findvisor/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/findvisor/storage/StorageManagerTest.java
@@ -41,7 +41,7 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonUserPrefsStorageTest} class.
          */
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(300, 600, 4, 6));
+        original.setGuiSettings(new GuiSettings(300, 600, 4, 6, 0.3));
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);


### PR DESCRIPTION
- Adjusted meeting panel size to be smaller by default
- Add feature of saving divider position between meeting panel and main app view to user prefs so the same size is loaded on next start up.

Closes #166 and closes #167.