### PR TITLE
Update help window

### DIFF
--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -69,6 +69,8 @@ public class HelpWindow extends UiPart<Stage> {
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
+    private static boolean hasNotShownOnce = true;
+
     @FXML
     private Button copyButton;
 
@@ -86,12 +88,6 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         root.setMaxHeight(Screen.getPrimary().getVisualBounds().getHeight());
-        // Required due to bug: https://bugs.openjdk.org/browse/JDK-8187899
-        // Setting max height does not change initial height. Initial height of window is not set but computed.
-        // Hence, there is a need to check for computed height and restrict it to the max size.
-        if (root.getHeight() > root.getMaxHeight()) {
-            root.setHeight(root.getMaxHeight());
-        }
         helpTable.setPadding(new Insets(10, 10, 10, 10));
         userGuideMessage.setText(HELP_MESSAGE);
         int i = 0;
@@ -190,6 +186,13 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void show() {
         logger.fine("Showing help page about the application.");
+        if (hasNotShownOnce) {
+            // Required for bug: https://bugs.openjdk.org/browse/JDK-8187899
+            if (getRoot().getHeight() > getRoot().getMaxHeight()) {
+                getRoot().setHeight(getRoot().getMaxHeight());
+            }
+            hasNotShownOnce = false;
+        }
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -9,6 +9,7 @@ import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.GridPane;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import seedu.findvisor.commons.core.LogsCenter;
 import seedu.findvisor.logic.commands.AddCommand;
@@ -84,6 +85,7 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow(Stage root) {
         super(FXML, root);
+        root.setMaxHeight(Screen.getPrimary().getBounds().getHeight());
         helpTable.setPadding(new Insets(10, 10, 10, 10));
         userGuideMessage.setText(HELP_MESSAGE);
         int i = 0;

--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -40,7 +40,7 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String HELP_COMMAND_MESSAGE = "Shows program usage instructions.";
 
     public static final String ADD_COMMAND_MESSAGE = "Adds a person to FINDvisor.";
-    public static final String DELETE_COMMAND_MESSAGE = "Deletes the person identified."
+    public static final String DELETE_COMMAND_MESSAGE = "Deletes the person identified"
                 + " by the index number used in the displayed person list.";
     public static final String FIND_COMMAND_MESSAGE = "Finds all persons whose information matches "
                 + "the specified keywords (case-insensitive) of the specified category and "

--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -88,6 +88,9 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         root.setMaxHeight(Screen.getPrimary().getVisualBounds().getHeight());
+        if (root.getMinHeight() > root.getMaxHeight()) {
+            root.setMinHeight(root.getMaxHeight());
+        }
         helpTable.setPadding(new Insets(10, 10, 10, 10));
         userGuideMessage.setText(HELP_MESSAGE);
         int i = 0;
@@ -186,6 +189,7 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void show() {
         logger.fine("Showing help page about the application.");
+        getRoot().show();
         if (hasNotShownOnce) {
             // Required for bug: https://bugs.openjdk.org/browse/JDK-8187899
             if (getRoot().getHeight() > getRoot().getMaxHeight()) {
@@ -193,7 +197,6 @@ public class HelpWindow extends UiPart<Stage> {
             }
             hasNotShownOnce = false;
         }
-        getRoot().show();
         getRoot().centerOnScreen();
     }
 

--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -85,7 +85,13 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow(Stage root) {
         super(FXML, root);
-        root.setMaxHeight(Screen.getPrimary().getBounds().getHeight());
+        root.setMaxHeight(Screen.getPrimary().getVisualBounds().getHeight());
+        // Required due to bug: https://bugs.openjdk.org/browse/JDK-8187899
+        // Setting max height does not change initial height. Initial height of window is not set but computed.
+        // Hence, there is a need to check for computed height and restrict it to the max size.
+        if (root.getHeight() > root.getMaxHeight()) {
+            root.setHeight(root.getMaxHeight());
+        }
         helpTable.setPadding(new Insets(10, 10, 10, 10));
         userGuideMessage.setText(HELP_MESSAGE);
         int i = 0;

--- a/src/main/java/seedu/findvisor/ui/HelpWindow.java
+++ b/src/main/java/seedu/findvisor/ui/HelpWindow.java
@@ -69,7 +69,7 @@ public class HelpWindow extends UiPart<Stage> {
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
-    private static boolean hasNotShownOnce = true;
+    private boolean hasNotShownOnce = true;
 
     @FXML
     private Button copyButton;

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -24,7 +24,7 @@
 }
 
 .scroll-pane, .scroll-pane > .viewport {
-    -fx-background-color: transparent;
+    -fx-background-color: derive(#1d1d1d, 20%);
 }
 
 .label {

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -23,6 +23,10 @@
     -fx-background-color: derive(#1d1d1d, 20%);
 }
 
+.scroll-pane, .scroll-pane > .viewport {
+    -fx-background-color: transparent;
+}
+
 .label {
     -fx-background-color: derive(#1d1d1d, 20%);
     -fx-text-fill: white;

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -5,8 +5,6 @@
 <?import javafx.scene.Scene?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TableColumn?>
-<?import javafx.scene.control.TableView?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -11,7 +11,8 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="603" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.scene.control.ScrollPane?>
+<fx:root resizable="true" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="603" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -36,11 +37,9 @@
           </HBox>
         </top>
         <center>
-          <GridPane fx:id="helpTable">
-            <BorderPane.margin>
-              <Insets top="10" right="10" bottom="10" left="10" />
-            </BorderPane.margin>
-          </GridPane>
+          <ScrollPane fitToWidth="true">
+            <GridPane fx:id="helpTable" />
+          </ScrollPane>
         </center>
       </BorderPane>
     </Scene>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="250" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="603" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -5,14 +5,14 @@
 <?import javafx.scene.Scene?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.stage.Stage?>
 
-<?import javafx.scene.control.ScrollPane?>
-<fx:root resizable="true" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="603" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" minWidth="603" minHeight="250" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -21,27 +21,27 @@
       <stylesheets>
         <URL value="@HelpWindow.css" />
       </stylesheets>
-      <BorderPane fx:id="helpMessageContainer">
-        <top>
-          <HBox alignment="CENTER_LEFT" spacing="10">
-            <Label fx:id="userGuideMessage">
-             <HBox.margin>
-                <Insets top="10" right="10" bottom="10" left="10" />
-             </HBox.margin>
-            </Label>
-            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-              <padding>
-                <Insets top="5" right="5" bottom="5" left="5"/>
-              </padding>
-            </Button>
-          </HBox>
-        </top>
-        <center>
-          <ScrollPane fitToWidth="true">
-            <GridPane fx:id="helpTable" />
-          </ScrollPane>
-        </center>
-      </BorderPane>
+      <ScrollPane fitToWidth="true">
+        <BorderPane fx:id="helpMessageContainer">
+          <top>
+            <HBox alignment="CENTER_LEFT" spacing="10">
+              <Label fx:id="userGuideMessage">
+               <HBox.margin>
+                  <Insets top="10" right="10" bottom="10" left="10" />
+               </HBox.margin>
+              </Label>
+              <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
+                <padding>
+                  <Insets top="5" right="5" bottom="5" left="5"/>
+                </padding>
+              </Button>
+            </HBox>
+          </top>
+          <center>
+              <GridPane fx:id="helpTable" />
+          </center>
+        </BorderPane>
+      </ScrollPane>
     </Scene>
   </scene>
 </fx:root>


### PR DESCRIPTION
- Remove unnecessary import for HelpWindow.fxml
- Fix typo in delete command message
- Fix help window sizing issues for smaller screens
    1. Set max height of help window to screen height (main fix).
    2. Set min height of help window to screen height if it exceeds max height (required for fix 1). 
    3. Add scroll pane to help window or the commands will not be viewable (required for fix 1).
    4. Add CSS for scroll pane (required for fix 3).
    5. Resize the help window to respect max height when the computed height is more than screen height. This is required due to the bug: https://bugs.openjdk.org/browse/JDK-8187899 and hence, height has to be computed the first time the window is shown for the fix to be in effect (main fix).

The changes are made to fix the bug and retain most of the behavior in v1.3.

Fixes #227, fixes #213, fixes #272 