### PR TITLE
Add clear definition of target user in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -13,7 +13,7 @@ title: User Guide
 <div style="page-break-after: always;"></div>
 
 ## About FINDvisor
-FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for use via a Command Line Interface ([CLI](https://aws.amazon.com/what-is/cli/#:~:text=A%20command%20line%20interface%20(CLI,all%20applications%20and%20software%20systems.))), suitable for individuals who prefer typing over mouse interactions.
+FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based mobile phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for typists, enabling individuals who type fast to perform contact management and meeting scheduling tasks efficiently.
 
 FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed and offers the capability to manage their meetings with their contacts.
 ## Quick start

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@ title: User Guide
 ## About FINDvisor
 FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based mobile phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for typists, enabling individuals who type fast to perform contact management and meeting scheduling tasks efficiently.
 
-FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed and offers the capability to manage their meetings with their contacts.
+FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed, while offering the capability to manage their meeting details with their contacts
 ## Quick start
 
 1. Ensure you have Java `11` or above installed in your Computer.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@ title: User Guide
 ## About FINDvisor
 FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based mobile phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for typists, enabling individuals who type fast to perform contact management and meeting scheduling tasks efficiently.
 
-FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed, while offering the capability to manage their meeting details with their contacts
+FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed, while offering the capability to manage their meeting details with their contacts.
 ## Quick start
 
 1. Ensure you have Java `11` or above installed in your Computer.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -2,16 +2,20 @@
 layout: page
 title: User Guide
 ---
+## Table of Contents
+{:.no_toc}
 
-FINDvisor is a **desktop app for financial advisors to manage contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, FINDvisor can get your contact management and meeting scheduling tasks done faster than traditional GUI apps.
-
-* Table of Contents
+* ToC
 {:toc}
 
 --------------------------------------------------------------------------------------------------------------------
 
 <div style="page-break-after: always;"></div>
 
+## About FINDvisor
+FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for use via a Command Line Interface ([CLI](https://aws.amazon.com/what-is/cli/#:~:text=A%20command%20line%20interface%20(CLI,all%20applications%20and%20software%20systems.))), suitable for individuals who prefer typing over mouse interactions.
+
+FINDvisor enables financial advisors to quickly save and retrieve the following contact's information: Name, Phone Number, Email, Address. It also allows financial advisors to create a remark and additional tags for a specific contact when needed. Lastly, FINDvisor offer financial advisors the ability to manage their meetings with their contacts.
 ## Quick start
 
 1. Ensure you have Java `11` or above installed in your Computer.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@ title: User Guide
 ## About FINDvisor
 FINDvisor is a desktop app for **Singapore-based** financial advisors to manage contacts with **Singapore-based phone numbers**. If you **frequently schedule meetings and require quick access to your contacts' details**, then FINDvisor is the tool for you. It is optimized for use via a Command Line Interface ([CLI](https://aws.amazon.com/what-is/cli/#:~:text=A%20command%20line%20interface%20(CLI,all%20applications%20and%20software%20systems.))), suitable for individuals who prefer typing over mouse interactions.
 
-FINDvisor enables financial advisors to quickly save and retrieve the following contact's information: Name, Phone Number, Email, Address. It also allows financial advisors to create a remark and additional tags for a specific contact when needed. Lastly, FINDvisor offer financial advisors the ability to manage their meetings with their contacts.
+FINDvisor enables financial advisors to quickly save and retrieve the following contact's information such as name, phone number, email and physical address. It also allows financial advisors to add a remark and tags to specific contacts where needed and offers the capability to manage their meetings with their contacts.
 ## Quick start
 
 1. Ensure you have Java `11` or above installed in your Computer.


### PR DESCRIPTION
- Move the description to a section titled "About FINDvisor"
- Table of Contents now has its own section heading

Closes #251 